### PR TITLE
Integrate Stripe Paysheets for paymentscreens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,7 @@ export type RootStackParamList = {
     eventId: string;
     event?: any;
     selectedTier?: { id: string; title: string; price: string };
+    openOrderSummary?: boolean;
   };
   VerifyLocation: undefined;
   CheckinScreen: undefined;
@@ -20,6 +21,7 @@ export type RootStackParamList = {
   BrowseAll: undefined;
   PaymentScreen: {
     eventId?: string;
+    event?: any;
     ticketTierId?: string;
     ticketTierName?: string;
     ticketPrice?: string;

--- a/components/OrderSummaryModal.tsx
+++ b/components/OrderSummaryModal.tsx
@@ -44,10 +44,10 @@ const OrderSummaryModal = forwardRef<
     onClose,
     onContinue,
   },
-  ref
+  ref,
 ) {
   const bottomSheetRef = useRef<BottomSheetModal>(null);
-  const [quantity, setQuantity] = useState(3);
+  const [quantity, setQuantity] = useState(1);
   const [promoCode, setPromoCode] = useState("");
 
   useImperativeHandle(ref, () => ({
@@ -82,7 +82,7 @@ const OrderSummaryModal = forwardRef<
         appearsOnIndex={0}
       />
     ),
-    []
+    [],
   );
 
   return (

--- a/components/PurpleGradientSpinner.tsx
+++ b/components/PurpleGradientSpinner.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useRef } from "react";
+import { View, StyleSheet, Animated, Easing } from "react-native";
+
+const PURPLE_GRADIENT = [
+  "#421570",
+  "#F4EAFE",
+  "#EFE0FE",
+  "#DEBFFD",
+  "#B574EC",
+  "#903BE7",
+  "#7626C6",
+  "#6E23BA",
+  "#6E23BA",
+];
+
+type Props = {
+  size?: number;
+  barWidth?: number;
+  barHeight?: number;
+  /** Spin duration in ms. Higher = slower. Default 1000. */
+  duration?: number;
+};
+
+export default function PurpleGradientSpinner({
+  size = 48,
+  barWidth,
+  barHeight,
+  duration = 1000,
+}: Props) {
+  const spinValue = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.timing(spinValue, {
+        toValue: 1,
+        duration,
+        easing: Easing.linear,
+        useNativeDriver: true,
+      }),
+    );
+    animation.start();
+    return () => animation.stop();
+  }, [spinValue, duration]);
+
+  const rotate = spinValue.interpolate({
+    inputRange: [0, 1],
+    outputRange: ["0deg", "360deg"],
+  });
+
+  const barCount = 9;
+  const angleStep = 360 / barCount;
+  const resolvedBarWidth = barWidth ?? Math.max(2, size / 8);
+  const innerRadius = size * 0.2;
+  const outerRadius = size / 2 - 2;
+  const resolvedBarHeight = barHeight ?? Math.max(4, outerRadius - innerRadius);
+  const midRadius = innerRadius + resolvedBarHeight / 2;
+  const cx = size / 2;
+  const cy = size / 2;
+
+  return (
+    <Animated.View
+      style={[
+        styles.container,
+        { width: size, height: size, transform: [{ rotate }] },
+      ]}
+    >
+      {PURPLE_GRADIENT.map((color, i) => {
+        const theta = (i * angleStep * Math.PI) / 180;
+        const x = cx + midRadius * Math.sin(theta) - resolvedBarWidth / 2;
+        const y = cy - midRadius * Math.cos(theta) - resolvedBarHeight / 2;
+        return (
+          <View
+            key={i}
+            style={[
+              styles.bar,
+              {
+                width: resolvedBarWidth,
+                height: resolvedBarHeight,
+                backgroundColor: color,
+                left: x,
+                top: y,
+                transform: [{ rotate: `${i * angleStep}deg` }],
+              },
+            ]}
+          />
+        );
+      })}
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: "relative",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  bar: {
+    position: "absolute",
+    borderRadius: 3,
+  },
+});

--- a/screens/EventDetailsScreen.tsx
+++ b/screens/EventDetailsScreen.tsx
@@ -471,8 +471,10 @@ export default function EventDetailsScreen() {
         eventDescription={(event as any)?.description}
         onSelectTicket={(tier) => {
           ticketModalRef.current?.dismiss();
+          // Prefer backend UUID so checkout API accepts it
+          const id = (event as any)?.uuid ?? eventId ?? (event as any)?.id ?? "";
           navigation.navigate("RegisterEvent", {
-            eventId: eventId ?? "",
+            eventId: String(id),
             event,
             selectedTier: tier,
           });

--- a/screens/PaymentScreen.tsx
+++ b/screens/PaymentScreen.tsx
@@ -1,12 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
-import {
-  View,
-  Text,
-  StyleSheet,
-  ActivityIndicator,
-  Alert,
-  Pressable,
-} from "react-native";
+import { View, Text, StyleSheet, Alert, Pressable } from "react-native";
 import { StatusBar } from "expo-status-bar";
 import { useStripe } from "@stripe/stripe-react-native";
 import Constants from "expo-constants";
@@ -14,6 +7,7 @@ import { useNavigation, useRoute, RouteProp } from "@react-navigation/native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import type { RootStackParamList } from "../App";
 import PrimaryButton from "../components/PrimaryButton";
+import PurpleGradientSpinner from "../components/PurpleGradientSpinner";
 import { getToken } from "../utils/auth";
 
 type NavigationProp = NativeStackNavigationProp<
@@ -25,14 +19,21 @@ type PaymentScreenRoute = RouteProp<RootStackParamList, "PaymentScreen">;
 const BACKEND_URL = Constants.expoConfig?.extra?.BACKEND_URL;
 const CREATE_PAYMENT_SHEET_ENDPOINT = "/checkout";
 
-const PaymentScreen = () => {
+/**
+ * Dummy UUIDs for testing PaymentSheet (dev only). Must match real events/ticket types in the backend.
+ */
+const DUMMY_EVENT_ID = "9bc99614-c742-4a12-8885-595fcc326885";
+const DUMMY_TICKET_TYPE_ID = "7c2178d4-4a89-4645-9c2e-b43b8e397dcc";
+
+const PaymentScreen: React.FC = () => {
   const navigation = useNavigation<NavigationProp>();
   const route = useRoute<PaymentScreenRoute>();
   const { initPaymentSheet, presentPaymentSheet } = useStripe();
   const [loading, setLoading] = useState(false);
 
   const {
-    eventId,
+    eventId: eventIdParam,
+    event,
     ticketTierId,
     ticketTierName,
     ticketPrice,
@@ -42,11 +43,12 @@ const PaymentScreen = () => {
     total,
     promoCode = "",
   } = route.params ?? {};
+  const eventId = eventIdParam ?? (event as any)?.uuid ?? (event as any)?.id;
 
   const fetchPaymentSheetParams = async () => {
     if (!BACKEND_URL) {
       throw new Error(
-        "BACKEND_URL is not set. Add BACKEND_URL to your .env file and restart Expo."
+        "BACKEND_URL is not set. Add BACKEND_URL to your .env file and restart Expo.",
       );
     }
 
@@ -55,12 +57,37 @@ const PaymentScreen = () => {
       throw new Error("You must be logged in to complete payment.");
     }
 
-    // Calculate amount in cents (Stripe requires integer cents)
-    const amountInCents = total
-      ? Math.round(parseFloat(total) * 100)
-      : ticketPrice
-        ? Math.round(parseFloat(ticketPrice.replace(/[^0-9.]/g, "")) * quantity * 100)
-        : 0;
+    const uuidRegex =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    let resolvedEventId =
+      eventId && uuidRegex.test(String(eventId)) ? eventId : null;
+    let resolvedTicketTypeId =
+      ticketTierId && uuidRegex.test(String(ticketTierId))
+        ? ticketTierId
+        : null;
+
+    if (__DEV__ && (!resolvedEventId || !resolvedTicketTypeId)) {
+      resolvedEventId = resolvedEventId ?? DUMMY_EVENT_ID;
+      resolvedTicketTypeId = resolvedTicketTypeId ?? DUMMY_TICKET_TYPE_ID;
+    }
+
+    if (!resolvedEventId || !uuidRegex.test(String(resolvedEventId))) {
+      throw new Error(
+        "Checkout requires a valid event UUID. Ensure your API returns event.uuid (or event.id as a UUID) and that you navigated from an event loaded from the API.",
+      );
+    }
+    if (
+      !resolvedTicketTypeId ||
+      !uuidRegex.test(String(resolvedTicketTypeId))
+    ) {
+      throw new Error("A valid ticket type ID (UUID) is required to checkout.");
+    }
+    const items = [
+      {
+        ticketTypeId: resolvedTicketTypeId,
+        quantity: quantity ?? 1,
+      },
+    ];
 
     const response = await fetch(
       `${BACKEND_URL}${CREATE_PAYMENT_SHEET_ENDPOINT}`,
@@ -71,18 +98,12 @@ const PaymentScreen = () => {
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
-          eventId,
-          ticketTierId,
-          ticketTierName,
-          quantity,
-          amount: amountInCents,
+          eventId: resolvedEventId,
+          items,
           currency: "usd",
-          subtotal: subtotal ? parseFloat(subtotal) : undefined,
-          fees: fees ? parseFloat(fees) : undefined,
-          total: total ? parseFloat(total) : undefined,
-          promoCode: promoCode || undefined,
+          ...(promoCode ? { promoCode } : {}),
         }),
-      }
+      },
     );
 
     if (!response.ok) {
@@ -90,13 +111,12 @@ const PaymentScreen = () => {
       throw new Error(`Stripe setup failed: ${response.status} - ${text}`);
     }
 
-    const { paymentIntentClientSecret, ephemeralKey, customer } =
-      await response.json();
-
+    const data = await response.json();
     return {
-      paymentIntentClientSecret,
-      ephemeralKey,
-      customer,
+      paymentIntentClientSecret:
+        data.clientSecret ?? data.paymentIntentClientSecret,
+      ephemeralKey: data.ephemeralKey,
+      customer: data.customerId ?? data.customer,
     };
   };
 
@@ -113,6 +133,36 @@ const PaymentScreen = () => {
         paymentIntentClientSecret,
         merchantDisplayName: "Georim",
         allowsDelayedPaymentMethods: true,
+        returnURL: "georim://stripe-redirect",
+        appearance: {
+          colors: {
+            primary: "#932FF8",
+            background: "#05031B",
+            componentBackground: "#1E1E3F",
+            componentBorder: "#E5E7EB",
+            componentDivider: "#6B7280",
+            primaryText: "#FFFFFF",
+            secondaryText: "#8F8E9B",
+            componentText: "#FFFFFF",
+            placeholderText: "#8F8E9B",
+            icon: "#FFFFFF",
+            error: "#EF4444",
+          },
+          shapes: {
+            borderRadius: 12,
+            borderWidth: 1,
+          },
+          primaryButton: {
+            colors: {
+              background: "#932FF8",
+              text: "#FFFFFF",
+              border: "#932FF8",
+            },
+            shapes: {
+              borderRadius: 15,
+            },
+          },
+        },
       });
 
       if (initError) {
@@ -123,7 +173,21 @@ const PaymentScreen = () => {
       const { error } = await presentPaymentSheet();
 
       if (error) {
-        if (error.code !== "Canceled") {
+        if (error.code === "Canceled") {
+          navigation.navigate("RegisterEvent", {
+            eventId: eventId ?? "",
+            event,
+            selectedTier:
+              ticketTierId && ticketTierName && ticketPrice
+                ? {
+                    id: ticketTierId,
+                    title: ticketTierName,
+                    price: ticketPrice,
+                  }
+                : undefined,
+            openOrderSummary: true,
+          });
+        } else {
           Alert.alert("Payment canceled", error.message);
         }
         return;
@@ -155,7 +219,7 @@ const PaymentScreen = () => {
 
       <View style={styles.content}>
         {loading ? (
-          <ActivityIndicator size="large" color="#FFFFFF" />
+          <PurpleGradientSpinner size={56} duration={2000} />
         ) : (
           <PrimaryButton title="Pay now" onPress={openPaymentSheet} />
         )}

--- a/screens/RegisterEventScreen.tsx
+++ b/screens/RegisterEventScreen.tsx
@@ -14,7 +14,12 @@ import {
   ViewToken,
   Platform,
 } from "react-native";
-import { useNavigation, useRoute, RouteProp } from "@react-navigation/native";
+import {
+  useNavigation,
+  useRoute,
+  RouteProp,
+  useFocusEffect,
+} from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import { BlurView } from "expo-blur";
@@ -84,7 +89,16 @@ function RegisterEventScreen() {
   const navigation = useNavigation<any>();
   const route = useRoute<RegisterEventRoute>();
   const insets = useSafeAreaInsets();
-  const { eventId, event, selectedTier } = route.params ?? {};
+  const { eventId, event, selectedTier, openOrderSummary } = route.params ?? {};
+
+  useFocusEffect(
+    useCallback(() => {
+      if (openOrderSummary) {
+        orderSummaryModalRef.current?.present();
+        navigation.setParams({ openOrderSummary: false } as any);
+      }
+    }, [openOrderSummary, navigation])
+  );
 
   const [registrationType, setRegistrationType] = useState("");
   const [selectedCohort, setSelectedCohort] = useState<string | null>(null);
@@ -662,19 +676,21 @@ function RegisterEventScreen() {
         ticketPrice={(selectedTier as any)?.price}
         ticketTierId={(selectedTier as any)?.id}
         eventId={eventId}
-        onContinue={(orderData) =>
+        onContinue={(orderData) => {
+          const tier = selectedTier as any;
           navigation.navigate("PaymentScreen", {
-            eventId,
-            ticketTierId: (selectedTier as any)?.id,
-            ticketTierName: (selectedTier as any)?.title,
-            ticketPrice: (selectedTier as any)?.price,
+            eventId: event?.uuid ?? eventId,
+            event,
+            ticketTierId: tier?.uuid ?? tier?.id,
+            ticketTierName: tier?.title,
+            ticketPrice: tier?.price,
             quantity: orderData.quantity,
             subtotal: orderData.subtotal,
             fees: orderData.fees,
             total: orderData.total,
             promoCode: orderData.promoCode,
-          })
-        }
+          });
+        }}
       />
     </View>
   );


### PR DESCRIPTION
Event Registration Flow
Overview
This section describes the end-to-end process for registering for an event, from viewing event details to completing payment with Stripe.
1. Event Details → Ticket Selection
Screen: EventDetailsScreen
•	User views event details.
•	User taps Register, which opens the TicketSelectionModal as a bottom sheet.
Component: TicketSelectionModal
•	Displays available ticket tiers (e.g., General Admission, VIP, Premium Guests).
•	User selects a tier; the modal dismisses and navigates to RegisterEvent with eventId, event, and selectedTier.
2. Registration Form
Screen: RegisterEventScreen
Step 1 – More information
•	User completes fields for registration type, cohort, area of study, institution, dietary restrictions (optional), accessibility requirements (optional), and shirt size.
•	User taps Next to proceed to a summary view.
Step 2 – Summary
•	User reviews the entered data.
•	User taps Submit, which opens the OrderSummaryModal.
3. Order Summary → Payment
Component: OrderSummaryModal (bottom sheet)
•	Shows selected ticket tier and price.
•	Allows user to change quantity and enter a promo code.
•	Displays subtotal, fees, and total.
•	User taps Continue, navigating to PaymentScreen with order data: eventId, event, ticketTierId, quantity, subtotal, fees, total, promoCode.
4. Payment (Stripe)
Screen: PaymentScreen
•	Auth: User must be logged in (getToken()).
•	Checkout API: On mount, calls POST ${BACKEND_URL}/checkout with:
•	eventId (UUID)
•	items: [{ ticketTypeId, quantity }]
•	currency: "usd"
•	promoCode (if provided)
•	Stripe setup: Uses initPaymentSheet with paymentIntentClientSecret, ephemeralKey, and customer from the backend.
•	UX: Shows PurpleGradientSpinner while loading, then presents Stripe PaymentSheet automatically.
•	Styling: PaymentSheet uses dark theme (e.g., #05031B, #1E1E3F, #932FF8).
•	Return URL: georim://stripe-redirect for redirect-based flows.
Outcomes:
•	Success: Navigate to EventSuccess.
•	User cancels PaymentSheet: Navigate back to RegisterEvent with openOrderSummary: true; OrderSummaryModal reopens.
•	User taps “Cancel and go back”: Navigate back without reopening the order summary.
5. Success
Screen: EventSuccessScreen
•	Shows payment success confirmation.
Technical Notes
•	Stripe provider: StripeProvider wraps the app in MainLayout.tsx.
•	Route params: RegisterEvent and PaymentScreen receive full order context via route params.
•	UUID validation: Checkout expects valid event and ticket-type UUIDs; dev builds can use fallback UUIDs when needed.
•	PaymentSheet cancel handling: Users who cancel are returned to the registration flow and can retry payment without re-entering details.